### PR TITLE
Proof formats - edits

### DIFF
--- a/index.html
+++ b/index.html
@@ -733,18 +733,18 @@ particular proof format, the specification and use of additional proof formats
 is supported.
       </p>
         <section>
-            <h2>Benefits of JWTs</h2>
+            <h3>Benefits of JWTs</h3>
 
             <p>
-                The Verifiable Credentials Data Model is designed to be compatible with a
-                variety of existing and emerging syntaxes and digital proof formats. Each
-                approach has benefits and drawbacks. The following table is intended to
-                summarize a number of these native trade-offs.
+The Verifiable Credentials Data Model is designed to be compatible with a
+variety of existing and emerging syntaxes and digital proof formats. Each
+approach has benefits and drawbacks. The following table is intended to
+summarize a number of these native trade-offs.
             </p>
 
             <p>
-                The table below compares three syntax and proof format ecosystems; JSON+JWTs,
-                JSON-LD+JWTs, and JSON-LD+LD-Proofs.
+The table below compares three syntax and proof format ecosystems; JSON+JWTs,
+JSON-LD+JWTs, and JSON-LD+LD-Proofs.
             </p>
 
             <table class="simple" id="#pfatable">
@@ -760,7 +760,7 @@ is supported.
                 <tbody>
                 <tr>
                     <td>
-                        <a href="#pf1a">PF1a.</a> Proof format supports Zero-Knowledge Proofs.
+<a href="#pf1a">PF1a.</a> Proof format supports Zero-Knowledge Proofs.
                     </td>
                     <td class="supported">✓</td>
                     <td class="supported">✓</td>
@@ -768,8 +768,8 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf2a">PF2a.</a> Proof format supports arbitrary proofs such as Proof
-                        of Work, Timestamp Proofs, and Proof of Stake.
+<a href="#pf2a">PF2a.</a> Proof format supports arbitrary proofs such as Proof
+of Work, Timestamp Proofs, and Proof of Stake.
                     </td>
                     <td class="supported">✓</td>
                     <td class="supported">✓</td>
@@ -777,7 +777,7 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf3a">PF3a.</a> Based on existing official standards.
+<a href="#pf3a">PF3a.</a> Based on existing official standards.
                     </td>
                     <td class="supported">✓</td>
                     <td class="missing">✖</td>
@@ -785,7 +785,7 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf4a">PF4a.</a> Designed to be small in size.
+<a href="#pf4a">PF4a.</a> Designed to be small in size.
                     </td>
                     <td class="supported">✓</td>
                     <td class="missing">✖</td>
@@ -793,7 +793,7 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf5a">PF5a.</a> Offline support without further processing.
+<a href="#pf5a">PF5a.</a> Offline support without further processing.
                     </td>
                     <td class="supported">✓</td>
                     <td class="missing">✖</td>
@@ -801,7 +801,7 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf6a">PF6a.</a> Wide adoption in other existing standards.
+<a href="#pf6a">PF6a.</a> Wide adoption in other existing standards.
                     </td>
                     <td class="supported">✓</td>
                     <td class="supported">✓</td>
@@ -809,7 +809,7 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf7a">PF7a.</a> No type ambiguity.
+<a href="#pf7a">PF7a.</a> No type ambiguity.
                     </td>
                     <td class="supported">✓</td>
                     <td class="missing">✖</td>
@@ -817,7 +817,7 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf8a">PF8a.</a> Broad library support.
+<a href="#pf8a">PF8a.</a> Broad library support.
                     </td>
                     <td class="supported">✓</td>
                     <td class="missing">✖</td>
@@ -825,7 +825,7 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf9a">PF9a.</a> Easy to understand what is signed.
+<a href="#pf9a">PF9a.</a> Easy to understand what is signed.
                     </td>
                     <td class="supported">✓</td>
                     <td class="supported">✓</td>
@@ -833,7 +833,7 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf10a">PF10a.</a> Ability to be used as authn/authz token with existing systems.
+<a href="#pf10a">PF10a.</a> Ability to be used as authn/authz token with existing systems.
                     </td>
                     <td class="supported">✓</td>
                     <td class="supported">✓</td>
@@ -841,7 +841,7 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf11a">PF11a.</a> No additional canonicalization required.
+<a href="#pf11a">PF11a.</a> No additional canonicalization required.
                     </td>
                     <td class="supported">✓</td>
                     <td class="missing">✖</td>
@@ -849,7 +849,7 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf12a">PF12a.</a> No Internet PKI required.
+<a href="#pf12a">PF12a.</a> No Internet PKI required.
                     </td>
                     <td class="supported">✓</td>
                     <td class="missing">✖</td>
@@ -857,140 +857,139 @@ is supported.
                 </tr>
                 <tr>
                     <td>
-                        <a href="#pf13a">PF13a.</a> No resolution of external documents needed.
+<a href="#pf13a">PF13a.</a> No resolution of external documents needed.
                     </td>
                     <td class="supported">✓</td>
                     <td class="missing">✖</td>
                     <td class="missing">✖</td>
                 </tr>
 
-                </tbody>
+              </tbody>
             </table>
 
             <p class="note">
-                Some of the features listed in the table above are debateable, since a feature
-                can always be added to a particular syntax or digital proof format. The table
-                is intended to identify native features of each combination such that no
-                additional language design or extension is required to achieve the identified
-                feature. Features that all languages provide, such as the ability to express
-                numbers, have not been included for the purposes of brevity. Find more information
-                about different proof formats in the next section.
+Some of the features listed in the table above are debateable, since a feature
+can always be added to a particular syntax or digital proof format. The table
+is intended to identify native features of each combination such that no
+additional language design or extension is required to achieve the identified
+feature. Features that all languages provide, such as the ability to express
+numbers, have not been included for the purposes of brevity. Find more information
+about different proof formats in the next section.
             </p>
 
             <dl>
-                <dt id="pf1a">
-                    PF1a: Proof format supports Zero-Knowledge Proofs.
-                </dt>
+              <dt id="pf1a">
+PF1a: Proof format supports Zero-Knowledge Proofs.
+              </dt>
                 <dd>
-                    JWTs can embed `proof` attributes for repudiable proofs such as Zero-Knowledge Proofs.
-                    In that case, the JWS will not have an signature element.
+JWTs can embed `proof` attributes for repudiable proofs such as Zero-Knowledge Proofs.
+In that case, the JWS will not have an signature element.
                 </dd>
                 <dt id="pf2a">
-                    PF2a: Proof format supports arbitrary proofs such as Proof of Work, Timestamp
-                    Proofs, and Proof of Stake.
+PF2a: Proof format supports arbitrary proofs such as Proof of Work, Timestamp
+Proofs, and Proof of Stake.
                 </dt>
                 <dd>
-                    JWTs can embed `proof` attributes for any type of proofs such as Proof of Work, Timestamp,
-                    Proofs, and Proof Stake.
+JWTs can embed `proof` attributes for any type of proofs such as Proof of Work, Timestamp,
+Proofs, and Proof Stake.
                 </dd>
                 <dt id="pf3a">
-                    PF3a: Based on existing official standards.
+PF3a: Based on existing official standards.
                 </dt>
                 <dd>
-                    JSON and JWT are proposed and mature IETF standards. While JSON-LD 1.0 is in
-                    REC state in W3C, JSON-LD 1.1 is still in WD state. LD-Proofs are not standardized at all.
+JSON and JWT are proposed and mature IETF standards. While JSON-LD 1.0 is in
+REC state in W3C, JSON-LD 1.1 is still in WD state. LD-Proofs are not standardized at all.
                 </dd>
                 <dt id="pf4a">
-                    PF4a: Designed to be small in size.
+PF4a: Designed to be small in size.
                 </dt>
                 <dd>
-                    JSON was invented as a simple data format to be transmitted on the wire. A verifiable credential
-                    can be expressed by its attributes only, without the necessity to introduce additional meta-information
-                    such as @context. This makes the resulting JSON+JWT credential typically also smaller in size.
+JSON was invented as a simple data format to be transmitted on the wire. A verifiable credential
+can be expressed by its attributes only, without the necessity to introduce additional meta-information
+such as @context. This makes the resulting JSON+JWT credential typically also smaller in size.
                 </dd>
                 <dt id="pf5a">
-                    PF5a: Offline support without further processing.
+PF5a: Offline support without further processing.
                 </dt>
                 <dd>
-                    A JWT can fully describe itself without the need to retrieve or verify any external documents.
-                    JSON-LD requires the context to be queryable and requires further documents to be accessible
-                    to check the prevalent document, e.g., LD-Proof. Additional caching needs to be implemented
-                    to support offline use cases.
+A JWT can fully describe itself without the need to retrieve or verify any external documents.
+JSON-LD requires the context to be queryable and requires further documents to be accessible
+to check the prevalent document, e.g., LD-Proof. Additional caching needs to be implemented
+to support offline use cases.
                 </dd>
                 <dt id="pf6a">
-                    PF6a: Wide adoption in other existing standards.
+PF6a: Wide adoption in other existing standards.
                 </dt>
                 <dd>
-                    JWT founds its application in many other existing standards, e.g., OAuth2, OpenID Connect.
-                    This allows for backward compatibility with existing authentication and authorization
-                    frameworks without or with only minor modifications to these legacy systems.
+JWT founds its application in many other existing standards, e.g., OAuth2, OpenID Connect.
+This allows for backward compatibility with existing authentication and authorization
+frameworks without or with only minor modifications to these legacy systems.
                 </dd>
                 <dt id="pf7a">
-                    PF7a: No type ambiguity.
+PF7a: No type ambiguity.
                 </dt>
                 <dd>
-                    It is best practice that JSON data structures typically do not expect changing types of
-                    their internal attributes. JSON-LD has implicit support for compact form serialization
-                    which transforms arrays with a single element only to switch its data type. Developers
-                    writing parsers have to implement special handling of these data types, which results in
-                    more code, is more error-prone and sometimes does not allow parsers based on code
-                    generation, which rely on static types.
+It is best practice that JSON data structures typically do not expect changing types of
+their internal attributes. JSON-LD has implicit support for compact form serialization
+which transforms arrays with a single element only to switch its data type. Developers
+writing parsers have to implement special handling of these data types, which results in
+more code, is more error-prone and sometimes does not allow parsers based on code
+generation, which rely on static types.
                 </dd>
                 <dt id="pf8a">
-                    PF8a: Broad library support.
+PF8a: Broad library support.
                 </dt>
                 <dd>
-                    JWT and JSON due to its maturity and standardization, have a lot of open-source library
-                    support. While JSON-LD 1.0 is a standard and has support for different programming
-                    languages, it is still behind JSON which is often part of the native platform
-                    toolchain, e.g., JavaScript. For LD-Proofs, on the other hand, only a few scattered
-                    libraries exist.
+JWT and JSON due to its maturity and standardization, have a lot of open-source library
+support. While JSON-LD 1.0 is a standard and has support for different programming
+languages, it is still behind JSON which is often part of the native platform
+toolchain, e.g., JavaScript. For LD-Proofs, on the other hand, only a few scattered
+libraries exist.
                 </dd>
                 <dt id="pf9a">
-                    PF9a: Easy to understand what is signed.
+PF9a: Easy to understand what is signed.
                 </dt>
                 <dd>
-                    JWT makes it visible what is signed in contrast to LD-Proofs, e.g., LD Signatures, that
-                    are detached from the actual payload and contain links to external documents which makes
-                    it not obvious for a developer to figure out what is part of the signature.
+JWT makes it visible what is signed in contrast to LD-Proofs, e.g., LD Signatures, that
+are detached from the actual payload and contain links to external documents which makes
+it not obvious for a developer to figure out what is part of the signature.
                 </dd>
                 <dt id="pf10a">
-                    PF10a: Ability to be used as authn/authz token with existing systems.
+PF10a: Ability to be used as authn/authz token with existing systems.
                 </dt>
                 <dd>
-                    Many existing applications rely on JWT for authentication and authorization purposes.
-                    In theory, developers maintaining these applications could leverage JWT-based verifiable
-                    presentations in their current systems with minor or no modifications. LD-Proofs represents
-                    a new approach which would require more work to achieve the same result.
+Many existing applications rely on JWT for authentication and authorization purposes.
+In theory, developers maintaining these applications could leverage JWT-based verifiable
+presentations in their current systems with minor or no modifications. LD-Proofs represents
+a new approach which would require more work to achieve the same result.
                 </dd>
                 <dt id="pf11a">
-                    PF11a: No additional canonicalization required.
+PF11a: No additional canonicalization required.
                 </dt>
                 <dd>
-                    Beyond base64 URL encoding JSON and JWT don't require any canonicalization to be transmitted
-                    on the wire. The JWS can be calculated on any data inside of the payload. This results in less
-                    computation, less complexity, and light-weight libraries compared to JSON-LD and LD-Proofs where
-                    canonicalization is required.
+Beyond base64 URL encoding JSON and JWT don't require any canonicalization to be transmitted
+on the wire. The JWS can be calculated on any data inside of the payload. This results in less
+computation, less complexity, and light-weight libraries compared to JSON-LD and LD-Proofs where
+canonicalization is required.
                 </dd>
                 <dt id="pf12a">
-                    PF12a: No Internet PKI required.
+PF12a: No Internet PKI required.
                 </dt>
                 <dd>
-                    JSON-LD and LD-Proofs rely on resolving external documents, e.g., <code>@context</code>. This means that
-                    a verifiable credential system would rely on existing Internet PKI to a certain extend and
-                    cannot be fully decentralized. A JWT-based system does not need to introduce this dependency.
+JSON-LD and LD-Proofs rely on resolving external documents, e.g., <code>@context</code>. This means that
+a verifiable credential system would rely on existing Internet PKI to a certain extend and
+cannot be fully decentralized. A JWT-based system does not need to introduce this dependency.
                 </dd>
                 <dt id="pf13a">
-                    PF13a: No resolution of external documents needed.
+PF13a: No resolution of external documents needed.
                 </dt>
                 <dd>
-                    JSON-LD and LD-Proofs require the resolution of external documents, which leads to an
-                    increased network load for the verifier of a verifiable presentation. This needs to be
-                    mitigated through caching strategies.
+JSON-LD and LD-Proofs require the resolution of external documents, which leads to an
+increased network load for the verifier of a verifiable presentation. This needs to be
+mitigated through caching strategies.
                 </dd>
             </dl>
         </section>
-
       <section>
         <h2>Benefits of JSON-LD and LD-Proofs</h2>
 

--- a/index.html
+++ b/index.html
@@ -1177,7 +1177,7 @@ systems.
               </tr>
               <tr>
                 <td>
-<a href="#pf19b">PF19b.</a> Canonicalization does not require more than base-64 encoding.
+<a href="#pf19b">PF19b.</a> Canonicalization requires only base-64 encoding.
                 </td>
                 <td class="supported">✖</td>
                 <td class="supported">✖</td>
@@ -1421,7 +1421,7 @@ converstion step are required for <a>verifiable credentials</a> and
 <a>verifiable presentations</a> protected by LD-Proofs.
             </dd>
             <dt id="pf19b">
-PF19b: Canonicalization does not require more than base-64 encoding.
+PF19b: Canonicalization requires only base-64 encoding.
             </dt>
             <dd>
 The JWT format utilizes a simple base-64 encoding format to generate the

--- a/index.html
+++ b/index.html
@@ -169,21 +169,27 @@ or send them to
     </section>
 
     <section>
-      <h2>Proofs</h2>
+      <h2>Proof Formats</h2>
       <em>This section is non-normative.</em>
 
       <p>
-          The VC Data Model is designed to be proof format agnostic. At the time of publication,
-          at least two proof formats are being actively utilized by implementers -- JSON Web Token (JWT)
-          and Linked Data Proofs.
-          The Working Group felt that <a href="https://w3c.github.io/vc-data-model/#proof-formats">documenting</a>
-          in the spec what these proof formats are and how they are being used would be beneficial to implementers.
-          
+The Verifiable Credentials Data Model is designed to be agnostic to any
+particular proof format. At the time of publication, at least two proof formats
+are being actively utilized by implementers -- JSON Web Token (JWT) and Linked
+Data Proofs. The Working Group felt that it would be beneficial to implementers
+to <a href="https://w3c.github.io/vc-data-model/#proof-formats">document</a> in
+the spec what these proof formats are and how they are being used.
       </p>
       <p>
-          The tables in section <a href="#pf1b">Benefits of JWTs</a> and section <a href="#pf1b">Benefits of JSON-LD
-          and LD-Proofs</a> that compare three syntax and proof format ecosystems; JSON+JWTs, JSON-LD+JWTs,
-          and JSON-LD+LD-Proofs.
+This guide provides tables in section <a href="#pf1b">Benefits of JWTs</a> and
+section <a href="#pf1b">Benefits of JSON-LD and LD-Proofs</a> that compare three
+syntax and proof format ecosystems; JSON+JWTs, JSON-LD+JWTs, and
+JSON-LD+LD-Proofs.
+      </p>
+      <p>
+Because the Verifiable Credentials Data Model is extensible, and agnostic to any
+particular proof format, the specification and use of additional proof formats
+is supported.
       </p>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -990,216 +990,216 @@ mitigated through caching strategies.
                 </dd>
             </dl>
         </section>
-      <section>
-        <h2>Benefits of JSON-LD and LD-Proofs</h2>
+        <section>
+          <h2>Benefits of JSON-LD and LD-Proofs</h2>
 
-        <p>
+          <p>
 The Verifiable Credentials Data Model is designed to be compatible with a
 variety of existing and emerging syntaxes and digital proof formats. Each
 approach has benefits and drawbacks. The following table is intended to
 summarize a number of these native trade-offs.
-        </p>
+          </p>
 
-        <p>
+          <p>
 The table below compares three syntax and proof format ecosystems; JSON+JWTs,
 JSON-LD+JWTs, and JSON-LD+LD-Proofs. Readers should be aware that
 Zero-Knowledge Proofs are currently proposed as a sub-type of LD-Proofs and
 thus fall into the final column below.
-        </p>
+          </p>
 
-        <table class="simple" id="#pfbtable">
-          <thead>
-            <tr>
-              <th style="text-align: center;">Feature</th>
-              <th style="text-align: center;">JSON<br>+<br>JWTs</th>
-              <th style="text-align: center;">JSON&#8209;LD<br>+<br>JWTs</th>
-              <th style="text-align: center;">JSON&#8209;LD<br>+<br>LD&#8209;Proofs</th>
-            </tr>
-          </thead>
+          <table class="simple" id="#pfbtable">
+            <thead>
+              <tr>
+                <th style="text-align: center;">Feature</th>
+                <th style="text-align: center;">JSON<br>+<br>JWTs</th>
+                <th style="text-align: center;">JSON&#8209;LD<br>+<br>JWTs</th>
+                <th style="text-align: center;">JSON&#8209;LD<br>+<br>LD&#8209;Proofs</th>
+              </tr>
+            </thead>
 
-          <tbody>
-            <tr>
-              <td>
+            <tbody>
+              <tr>
+                <td>
 <a href="#pf1b">PF1b.</a> Support for open world data modelling.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf2b">PF2b.</a> Universal identifier mechanism for JSON objects via
 the use of URIs.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf3b">PF3b.</a> A way to disambiguate properties shared among different
 JSON documents by mapping them to IRIs via a context.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf4b">PF4b.</a> A mechanism to refer to data in an external document,
 where the data may be merged with the local document without a merge conflict
 in semantics or structure.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf5b">PF5b.</a> The ability to annotate strings with their language.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf6b">PF6b.</a> A way to associate arbitrary datatypes, such as dates
 and times, with arbitrary property values.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf7b">PF7b.</a> A facility to express one or more directed graphs,
 such as a social network, in a single document.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf8b">PF8b.</a> Supports signature sets.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf9b">PF9b.</a> Embeddable in HTML such that search crawlers will
 index the machine-readable content.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf10b">PF10b.</a> Data on the wire is easy to debug and serialize to
 database systems.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf11b">PF11b.</a> Nesting signed data does not cause data size to
 double for every embedding.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf12b">PF12b.</a> Proof format supports Zero-Knowledge Proofs.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf13b">PF13b.</a> Proof format supports arbitrary proofs such as Proof
 of Work, Timestamp Proofs, and Proof of Stake.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf14b">PF14b.</a> Proofs can be expressed unmodified in other data
 syntaxes such as YAML, N-Quads, and CBOR.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf15b">PF15b.</a> Changing property-value ordering, or introducing
 whitespace does not invalidate signature.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf16b">PF16b.</a> Designed to easily support experimental signature
 systems.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf17b">PF17b.</a> Supports signature chaining.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf18b">PF18b.</a> Does not require pre-processing or post-processing.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
+                </td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
+              </tr>
+              <tr>
+                <td>
 <a href="#pf19b">PF19b.</a> Canonicalization requires more than base-64 encoding.
-              </td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-              <td class="missing">✖</td>
-            </tr>
-          </tbody>
-        </table>
+                </td>
+                <td class="supported">✓</td>
+                <td class="supported">✓</td>
+                <td class="missing">✖</td>
+              </tr>
+            </tbody>
+          </table>
 
-        <p class="note">
+          <p class="note">
 Some of the features listed in the table above are debateable, since a feature
 can always be added to a particular syntax or digital proof format. The table
 is intended to identify native features of each combination such that no
 additional language design or extension is required to achieve the identified
 feature. Features that all languages provide, such as the ability to express
 numbers, have not been included for the purposes of brevity.
-        </p>
+          </p>
 
-        <dl>
-          <dt id="pf1b">
+          <dl>
+            <dt id="pf1b">
 PF1b: Support for open world data modelling
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 An <em>open world data model</em> is one where any entity can make any
 statement about anything while simultaneously ensuring that the semantics of
 the statement are unambiguous. This specification is enabled by an open world
@@ -1207,22 +1207,22 @@ data model called Linked Data. One defining characteristic of supporting an open
 world data model is the ability to specify the semantic context in which data
 is being expressed. JSON-LD provides this mechanism via the
 <code>@context</code> property. JSON has no such feature.
-          </dd>
-          <dt id="pf2b">
+            </dd>
+            <dt id="pf2b">
 PF2b: Universal identifier mechanism for JSON objects via the use of URIs.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 All entities in a JSON-LD document are identified either via an automatic URI,
 or via an explicit URI. This enables all entities in a document to be
 unambiguously referenced. JSON does not have a native URI type nor does it
 require objects to have one, making it difficult to impossible to unambiguously
 identify an entity expressed in JSON.
-          </dd>
-          <dt id="pf3b">
+            </dd>
+            <dt id="pf3b">
 PF3b: A way to disambiguate properties shared among different JSON documents by
 mapping them to IRIs via a context.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 All object properties in a JSON-LD document, such as the property "homepage",
 are either keywords or they are mapped to an IRI. This feature enables open
 world systems to identify the semantic meaning of the property in an unambiguous
@@ -1231,13 +1231,13 @@ JSON object properties are not mapped to IRIs, which result in ambiguities with
 respect to the semantic meaning of the property. For example, one JSON document
 might use "title" (meaning "book title") in a way that is semantically
 incompatible with another JSON document using "title" (meaning "job title").
-          </dd>
-          <dt id="pf4b">
+            </dd>
+            <dt id="pf4b">
 PF4b: A mechanism to refer to data in an external document, where the data may
 be merged with the local document without a merge conflict in semantics or
 structure.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 JSON-LD provides a mechanism that enables a data value to use a URL to refer
 to data outside of the local document. This external data may then be
 automatically merged with the local document without a merge conflict in
@@ -1247,61 +1247,61 @@ associated with the local document. While a JSON document can contain pointers
 to external data, interpreting the pointer is often application specific and
 usually does not support merging the external data to construct a richer data
 set.
-          </dd>
-          <dt id="pf5b">
+            </dd>
+            <dt id="pf5b">
 PF5b: The ability to annotate strings with their language.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 JSON-LD enables a developer to specify the language, such as English, French,
 or Japanese, in which a text string is expressed via the use of language tags.
 JSON does not provide such a feature.
-          </dd>
-          <dt id="pf6b">
+            </dd>
+            <dt id="pf6b">
 PF6b: A way to associate arbitrary datatypes, such as dates
 and times, with arbitrary property values.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 JSON-LD enables a developer to specify the data type of a property value,
 such as Date, unsigned integer, or Temperature by specifying it in the
 JSON-LD Context. JSON does not provide such a feature.
-          </dd>
-          <dt id="pf7b">
+            </dd>
+            <dt id="pf7b">
 PF7b: A facility to express one or more directed graphs, such as a social
 network, in a single document.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 JSON-LD's abstract data model supports the expression of information
 as a directed graph of labeled nodes and edges, which enables an open world
 data model to be supported. JSON's abstract data model only supports the
 expression of information as a tree of unlabeled nodes and edges, which
 restricts the types of relationships and structures that can be natively
 expressed in the language.
-          </dd>
-          <dt id="pf8b">
+            </dd>
+            <dt id="pf8b">
 PF8b: Supports signature sets.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 A signature set is an unordered set of signatures over a data payload. Use
 cases, such as cryptographic signatures applied to a legal contract,
 typically require more than one signature to be associated with the contract
 in order to legally bind two or more parties under the terms of the contract.
 Linked Data Proofs, including Linked Data Signatures, natively support sets of
 signatures. JWTs only enable a single signature over a single payload.
-          </dd>
-          <dt id="pf9b">
+            </dd>
+            <dt id="pf9b">
 PF9b: Embeddable in HTML such that search crawlers will index the
 machine-readable content.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 All major search crawlers natively parse and index information expressed as
 JSON-LD in HTML pages. LD-Proofs enable the current data format that search
 engines use to be extended to support digital signatures. JWTs have no mechanism
 to express data in HTML pages and are currently not indexed by search crawlers.
-          </dd>
-          <dt id="pf10b">
+            </dd>
+            <dt id="pf10b">
 PF10b: Data on the wire is easy to debug and serialize to database systems.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 When developers are debugging software systems, it is beneficial for them to be
 able to see the data that they are operating on using common debugging tools.
 Similarly, it is useful to be able to serialize data from the network to a
@@ -1313,12 +1313,12 @@ complicated pre and post processing steps to convert the data into JSON data
 while not destroying the digital signature. Similarly, schema-less databases,
 which are typically used to index JSON data, cannot index information
 that is expressed in an opaque base-64 encoded wrapper.
-          </dd>
-          <dt id="pf11b">
+            </dd>
+            <dt id="pf11b">
 PF11b: Nesting signed data does not cause data size to double for every
 embedding.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 When a JWT is encapsulated by another JWT, the entire payload must be base-64
 encoded in the initial JWT, and then base-64 encoded again in the encapsulating
 JWT. This is often necessary when a cryptographic signature is required on a
@@ -1328,11 +1328,11 @@ services. LD-Proofs do not require base-64 encoding the signed portion of a
 document and instead rely on a canonicalization process that is just as
 secure, and that only requires the cryptographic signature to be encoded
 instead of the entire payload.
-          </dd>
-          <dt id="pf12b">
+            </dd>
+            <dt id="pf12b">
 PF12b: Proof format supports Zero-Knowledge Proofs.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 The LD-Proof format is capable of modifying the algorithm that generates
 the hash or hashes that are cryptographically signed. This cryptographic
 agility enables digital signature systems, such as Zero-Knowledge Proofs,
@@ -1340,12 +1340,12 @@ to be layered on top of LD-Proofs instead of an entirely new digital signature
 container format to be created. JWTs are designed such that an entirely new
 digital signature container format will be required to support Zero-Knowledge
 Proofs.
-          </dd>
-          <dt id="pf13b">
+            </dd>
+            <dt id="pf13b">
 PF13b: Proof format supports arbitrary proofs such as Proof of Work, Timestamp
 Proofs, and Proof of Stake.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 The LD-Proof format was designed with a broader range of proof types in mind
 and supports cryptographic proofs beyond simple cryptographic signatures.
 These proof types are in common usage in systems such as decentralized ledgers
@@ -1354,24 +1354,24 @@ and provide additional guarantees to
 claim was made at a particular time or that a certain amount of energy was
 expended to generate a particular credential. The JWT format does not support
 arbitrary proof formats.
-          </dd>
-          <dt id="pf14b">
+            </dd>
+            <dt id="pf14b">
 PF14b: Proofs can be expressed unmodified in other data syntaxes such as XML,
 YAML, N-Quads, and CBOR.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 The LD-Proof format utilizes a canonicalization algorithm to generate a
 cryptographic hash that is used as an input to the cryptographic proof
 algorithm. This enables the bytes generated as the cryptographic proof to be
 compact and expressible in a variety of other syntaxes such as XML,
 YAML, N-Quads, and CBOR. Since JWTs require the use of JSON to be generated,
 they are inextricably tied to the JSON syntax.
-          </dd>
-          <dt id="pf15b">
+            </dd>
+            <dt id="pf15b">
 PF15b: Changing property-value ordering, or introducing whitespace does not
 invalidate signature.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 Since LD-Proofs utilize a canonicalization algorithm, the introduction of
 whitespace that does not change the meaning of the information being expressed
 has no effect on the final cryptographic hash over the information. This means
@@ -1382,11 +1382,11 @@ encode the payload using the base-64 format which is not resistant to
 whitespace formatting that has no effect on the information expressed. This
 shortcoming of JWTs make it challenging to, for example, express signed data in
 web pages that search crawlers index.
-          </dd>
-          <dt id="pf16b">
+            </dd>
+            <dt id="pf16b">
 PF16b: Designed to easily support experimental signature systems.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 The LD-Proof format is naturally extensible, not requiring the format to be
 extended in a formal international standards working group in order to
 prevent namespace collisions. The JWT format requires entries in a centralized
@@ -1397,11 +1397,11 @@ suites that are guaranteed to not conflict with other LD-Proof
 extensions. This approach enables developers to easily experiment with new
 cryptographic signature mechanisms that support selective disclosure,
 zero-knowledge proofs, and post-quantum algorithms.
-          </dd>
-          <dt id="pf17b">
+            </dd>
+            <dt id="pf17b">
 PF17b: Supports signature chaining.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 A signature chain is an ordered set of signatures over a data payload. Use
 cases, such as cryptographic signatures applied to a notarized document,
 typically require a signature by the signing party and then an additional one
@@ -1409,21 +1409,21 @@ by a notary to be made after the original signing party has made their
 signature. Linked Data Proofs, including Linked Data Signatures, natively
 support chains of signatures. JWTs only enable a single signature over a
 single payload.
-          </dd>
-          <dt id="pf18b">
+            </dd>
+            <dt id="pf18b">
 PF18b: Does not require pre-processing or post-processing.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 In order to encode a <a>verifiable credential</a> or a
 <a>verifiable presentation</a> in a JWT, an extra set of steps
 are required to convert the data to and from the JWT format. No such extra
 converstion step are required for <a>verifiable credentials</a> and
 <a>verifiable presentations</a> protected by LD-Proofs.
-          </dd>
-          <dt id="pf19b">
+            </dd>
+            <dt id="pf19b">
 PF19b: Canonicalization requires more than base-64 encoding.
-          </dt>
-          <dd>
+            </dt>
+            <dd>
 The JWT format utilizes a simple base-64 encoding format to generate the
 cryptographic hash of the data. The encoding format for LD-Proofs require
 a more complex canonicalization algorithm to generate the cryptographic

--- a/index.html
+++ b/index.html
@@ -1179,9 +1179,9 @@ systems.
                 <td>
 <a href="#pf19b">PF19b.</a> Canonicalization requires only base-64 encoding.
                 </td>
-                <td class="supported">✖</td>
-                <td class="supported">✖</td>
-                <td class="missing">✓</td>
+                <td class="missing">✖</td>
+                <td class="missing">✖</td>
+                <td class="supported">✓</td>
               </tr>
             </tbody>
           </table>

--- a/index.html
+++ b/index.html
@@ -173,12 +173,20 @@ or send them to
       <em>This section is non-normative.</em>
 
       <p>
-The Verifiable Credentials Data Model is designed to be agnostic to any
-particular proof format. At the time of publication, at least two proof formats
-are being actively utilized by implementers -- JSON Web Token (JWT) and Linked
-Data Proofs. The Working Group felt that it would be beneficial to implementers
-to <a href="https://w3c.github.io/vc-data-model/#proof-formats">document</a> in
-the spec what these proof formats are and how they are being used.
+The <a>verifiable credentials</a>
+<a href="https://w3c.github.io/vc-data-model/">data model </a> is designed to be
+proof format agnostic. <a href="https://w3c.github.io/vc-data-model/">The
+specification</a> does not normatively require any particular digital proof or
+signature format. While the data model is the canonical representation of a
+<a>verifiable credential</a> or <a>verifiable presentation</a>, the proving
+mechanisms for these are often tied to the syntax used in the transmission of
+the document between parties. As such, each proofing mechanism has to specify
+whether the validation of the proof is calculated against the state of the
+document as transmitted, against the transformed data model, or against another
+form. At the time of publication, at least two proof formats are being actively
+utilized by implementers and the Working Group felt that documenting what these
+proof formats are and how they are being used would be beneficial to
+implementers.
       </p>
       <p>
 This guide provides tables in section <a href="#pf1b">Benefits of JWTs</a> and

--- a/index.html
+++ b/index.html
@@ -717,8 +717,8 @@ the document between parties. As such, each proofing mechanism has to specify
 whether the validation of the proof is calculated against the state of the
 document as transmitted, against the transformed data model, or against another
 form. At the time of publication, at least two proof formats are being actively
-utilized by implementers and the Working Group felt that documenting what these
-proof formats are and how they are being used would be beneficial to
+utilized by implementers, and the Working Group felt that documenting what these
+proof formats are and how they are being used would be beneficial to other
 implementers.
       </p>
       <p>
@@ -1177,11 +1177,11 @@ systems.
               </tr>
               <tr>
                 <td>
-<a href="#pf19b">PF19b.</a> Canonicalization requires more than base-64 encoding.
+<a href="#pf19b">PF19b.</a> Canonicalization does not require more than base-64 encoding.
                 </td>
-                <td class="supported">✓</td>
-                <td class="supported">✓</td>
-                <td class="missing">✖</td>
+                <td class="supported">✖</td>
+                <td class="supported">✖</td>
+                <td class="missing">✓</td>
               </tr>
             </tbody>
           </table>
@@ -1421,11 +1421,11 @@ converstion step are required for <a>verifiable credentials</a> and
 <a>verifiable presentations</a> protected by LD-Proofs.
             </dd>
             <dt id="pf19b">
-PF19b: Canonicalization requires more than base-64 encoding.
+PF19b: Canonicalization does not require more than base-64 encoding.
             </dt>
             <dd>
 The JWT format utilizes a simple base-64 encoding format to generate the
-cryptographic hash of the data. The encoding format for LD-Proofs require
+cryptographic hash of the data. The encoding format for LD-Proofs requires
 a more complex canonicalization algorithm to generate the cryptographic
 hash. The benefits of the JWT approach are simplicity at the cost of
 encoding flexibility. The benefits of the LD-Proof approach are flexibility at

--- a/index.html
+++ b/index.html
@@ -991,7 +991,7 @@ mitigated through caching strategies.
             </dl>
         </section>
         <section>
-          <h2>Benefits of JSON-LD and LD-Proofs</h2>
+          <h3>Benefits of JSON-LD and LD-Proofs</h3>
 
           <p>
 The Verifiable Credentials Data Model is designed to be compatible with a

--- a/index.html
+++ b/index.html
@@ -168,40 +168,6 @@ or send them to
       </p>
     </section>
 
-    <section>
-      <h2>Proof Formats</h2>
-      <em>This section is non-normative.</em>
-
-      <p>
-The <a>verifiable credentials</a>
-<a href="https://w3c.github.io/vc-data-model/">data model </a> is designed to be
-proof format agnostic. <a href="https://w3c.github.io/vc-data-model/">The
-specification</a> does not normatively require any particular digital proof or
-signature format. While the data model is the canonical representation of a
-<a>verifiable credential</a> or <a>verifiable presentation</a>, the proving
-mechanisms for these are often tied to the syntax used in the transmission of
-the document between parties. As such, each proofing mechanism has to specify
-whether the validation of the proof is calculated against the state of the
-document as transmitted, against the transformed data model, or against another
-form. At the time of publication, at least two proof formats are being actively
-utilized by implementers and the Working Group felt that documenting what these
-proof formats are and how they are being used would be beneficial to
-implementers.
-      </p>
-      <p>
-This guide provides tables in section <a href="#pf1b">Benefits of JWTs</a> and
-section <a href="#pf1b">Benefits of JSON-LD and LD-Proofs</a> that compare three
-syntax and proof format ecosystems; JSON+JWTs, JSON-LD+JWTs, and
-JSON-LD+LD-Proofs.
-      </p>
-      <p>
-Because the Verifiable Credentials Data Model is extensible, and agnostic to any
-particular proof format, the specification and use of additional proof formats
-is supported.
-      </p>
-
-    </section>
-
     <section class="informative">
       <h2>Terminology</h2>
 
@@ -736,13 +702,36 @@ and examples of typical usage of the extension.
     </section>
 
     <section>
-      <h2>Cryptography</h2>
-
+      <h2>Proof Formats</h2>
       <em>This section is non-normative.</em>
 
       <p>
+The <a>verifiable credentials</a>
+<a href="https://w3c.github.io/vc-data-model/">data model </a> is designed to be
+proof format agnostic. <a href="https://w3c.github.io/vc-data-model/">The
+specification</a> does not normatively require any particular digital proof or
+signature format. While the data model is the canonical representation of a
+<a>verifiable credential</a> or <a>verifiable presentation</a>, the proving
+mechanisms for these are often tied to the syntax used in the transmission of
+the document between parties. As such, each proofing mechanism has to specify
+whether the validation of the proof is calculated against the state of the
+document as transmitted, against the transformed data model, or against another
+form. At the time of publication, at least two proof formats are being actively
+utilized by implementers and the Working Group felt that documenting what these
+proof formats are and how they are being used would be beneficial to
+implementers.
       </p>
-
+      <p>
+This guide provides tables in section <a href="#pf1b">Benefits of JWTs</a> and
+section <a href="#pf1b">Benefits of JSON-LD and LD-Proofs</a> that compare three
+syntax and proof format ecosystems; JSON+JWTs, JSON-LD+JWTs, and
+JSON-LD+LD-Proofs.
+      </p>
+      <p>
+Because the Verifiable Credentials Data Model is extensible, and agnostic to any
+particular proof format, the specification and use of additional proof formats
+is supported.
+      </p>
         <section>
             <h2>Benefits of JWTs</h2>
 


### PR DESCRIPTION
Combined `Proofs` and `Cryptography` into a single section called `Proof Formats`
Edited for clarity, line length, spacing, and to add links to terminology.
Removed a bunch of whitespace (and added a bit).