### PR TITLE
made Disputes its own section

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,8 +238,8 @@ A <a>subject</a> disputes a claim made by the <a>issuer</a>. For example, the
         </li>
         <li>
 An <a>entity</a> disputes a potentially false claim made by the <a>issuer</a>
-about a different <a>subject</a>. For example, an imposter claims the social
-security number for an <a>entity</a>.
+about a different <a>subject</a>. For example, an imposter has claimed the
+social security number for an <a>entity</a>.
         </li>
       </ul>
 

--- a/index.html
+++ b/index.html
@@ -222,46 +222,46 @@ There are many data verification languages, the following approach is one
 that should work for most use cases.
         </p>
       </section>
+    </section>
+    <section>
+      <h2>Disputes</h2>
 
-      <section>
-        <h3>Disputes</h3>
+      <p>
+There are at least two different cases to consider where an <a>entity</a>
+wants to dispute a <a>credential</a> issued by an <a>issuer</a>:
+      </p>
 
-        <p>
-  There are at least two different cases to consider where an <a>entity</a>
-  wants to dispute a <a>credential</a> issued by an <a>issuer</a>:
-        </p>
+      <ul>
+        <li>
+A <a>subject</a> disputes a claim made by the <a>issuer</a>. For example, the
+<code>address</code> <a>property</a> is incorrect or out of date.
+        </li>
+        <li>
+An <a>entity</a> disputes a potentially false claim made by the <a>issuer</a>
+about a different <a>subject</a>. For example, an imposter claims the social
+security number for an <a>entity</a>.
+        </li>
+      </ul>
 
-        <ul>
-          <li>
-  A <a>subject</a> disputes a claim made by the <a>issuer</a>. For example, the
-  <code>address</code> <a>property</a> is incorrect or out of date.
-          </li>
-          <li>
-  An <a>entity</a> disputes a potentially false claim made by the <a>issuer</a>
-  about a different <a>subject</a>. For example, an imposter claims the social
-  security number for an <a>entity</a>.
-          </li>
-        </ul>
+      <p>
+The mechanism for issuing a <code>DisputeCredential</code> is the same as
+for a regular <a>credential</a>, except that the <code>credentialSubject</code>
+identifier in the <code>DisputeCredential</code> property is the identifier of
+the disputed <a>credential</a>.
+      </p>
 
-        <p>
-  The mechanism for issuing a <code>DisputeCredential</code> is the same as
-  for a regular <a>credential</a>, except that the <code>credentialSubject</code>
-  identifier in the <code>DisputeCredential</code> property is the identifier of
-  the disputed <a>credential</a>.
-        </p>
+      <p>
+For example, if a <a>credential</a> with an identifier of
+<code>https://example.org/credentials/245</code> is disputed, an <a>entity</a>
+can issue one of the <a>credentials</a> shown below. In the first example, the
+<a>subject</a> might present this to the <a>verifier</a> along with the disputed
+<a>credential</a>. In the second example, the <a>entity</a> might publish the
+<code>DisputeCredential</code> in a public venue to make it known that the
+<a>credential</a> is disputed.
+      </p>
 
-        <p>
-  For example, if a <a>credential</a> with an identifier of
-  <code>https://example.org/credentials/245</code> is disputed, an <a>entity</a>
-  can issue one of the <a>credentials</a> shown below. In the first example, the
-  <a>subject</a> might present this to the <a>verifier</a> along with the disputed
-  <a>credential</a>. In the second example, the <a>entity</a> might publish the
-  <code>DisputeCredential</code> in a public venue to make it known that the
-  <a>credential</a> is disputed.
-        </p>
-
-        <pre class="example nohighlight" title="A subject disputes a credential">
-  {
+      <pre class="example nohighlight" title="A subject disputes a credential">
+{
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
     "https://www.w3.org/2018/credentials/examples/v1"
@@ -279,12 +279,11 @@ that should work for most use cases.
   "issuer": "https://example.com/people#me",
   "issuanceDate": "2017-12-05T14:27:42Z",
   "proof": { ... }
-  }
-        </pre>
+}
+      </pre>
 
-
-        <pre class="example nohighlight" title="Another entity disputes a credential">
-  {
+      <pre class="example nohighlight" title="Another entity disputes a credential">
+{
   "@context": "https://w3id.org/credentials/v1",
   "id": "http://example.com/credentials/321",
   "type": ["VerifiableCredential", "DisputeCredential"],
@@ -303,23 +302,21 @@ that should work for most use cases.
   "issuer": "https://example.com/people#me",
   "issuanceDate": "2017-12-05T14:27:42Z",
   "proof": { ... }
-  }
-        </pre>
+}
+      </pre>
 
-  <p> In the above <a>verifiable credential</a>, the <a>issuer</a> is claiming that
-  the address in the disputed <a>verifiable credential</a> is wrong. For example,
-  the <a>subject</a> might wrongly be claiming to have the same address as that of
-  the <a>issuer</a>.
-  </p>
-        <p class="note">
-  If a <a>credential</a> does not have an identifier, a content-addressed
-  identifier can be used to identify the disputed <a>credential</a>. Similarly,
-  content-addressed identifiers can be used to uniquely identify individual
-  claims.
-        </p>
-
-      </section>
-
+      <p>
+In the above <a>verifiable credential</a>, the <a>issuer</a> is claiming that
+the address in the disputed <a>verifiable credential</a> is wrong. For example,
+the <a>subject</a> might wrongly be claiming to have the same address as that of
+the <a>issuer</a>.
+      </p>
+      <p class="note">
+If a <a>credential</a> does not have an identifier, a content-addressed
+identifier can be used to identify the disputed <a>credential</a>. Similarly,
+content-addressed identifiers can be used to uniquely identify individual
+claims.
+      </p>
     </section>
 
     <section>


### PR DESCRIPTION
The `Disputes` section did not seem to fit under `Verification`
This PR makes it an independent section.
Signed-off-by: Brent <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-imp-guide/pull/30.html" title="Last updated on Aug 13, 2019, 3:11 PM UTC (3e6426e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/30/c73fb2e...brentzundel:3e6426e.html" title="Last updated on Aug 13, 2019, 3:11 PM UTC (3e6426e)">Diff</a>