### PR TITLE
moved hashlinks to new content integrity subsection of verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,6 +224,18 @@ that should work for most use cases.
       </section>
 
       <section>
+        <h3>Content Integrity Protection</h3>
+        <section>
+          <h4>Hashlinks</h4>
+
+          <p>
+            Hashlink URLs can be used to provide content integrity for links to
+            external resources.
+          </p>
+        </section>
+      </section>
+
+      <section>
         <h3>Disputes</h3>
 
         <p>
@@ -1507,15 +1519,6 @@ more complex and larger than some older signature schemes.
 
         <p>
           Use COSE Web Keys to express key material.
-        </p>
-      </section>
-
-      <section>
-        <h3>Hashlinks</h3>
-
-        <p>
-          Hashlink URLs can be used to provide content integrity for links to
-          external resources.
         </p>
       </section>
 


### PR DESCRIPTION
As content integrity protection is a vital component of verification, I created a content integrity subsection for verification.
As hashlinks are a prime example of how to provide content integrity protection, I moved their section to the new content integrity section.

Signed-off-by: Brent <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-imp-guide/pull/34.html" title="Last updated on Aug 13, 2019, 3:09 PM UTC (7c7d7dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/34/18779a7...brentzundel:7c7d7dc.html" title="Last updated on Aug 13, 2019, 3:09 PM UTC (7c7d7dc)">Diff</a>