### PR TITLE
Add text to verification section

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,8 +228,8 @@ these are described in greater detail below.
           <h4>Hashlinks</h4>
 
           <p>
-Hashlink URLs can be used to provide content integrity for links to external
-resources.
+<a href="https://tools.ietf.org/html/draft-sporny-hashlink-00">Hashlink URLs</a>
+can be used to provide content integrity for links to external resources.
           </p>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@ may include data schemas, identifiers, public keys, etc.
         </p>
         <p>
 There are a number of ways to provide content integrity protection. A few of
-them are described in greater detail below.
+these are described in greater detail below.
         </p>
         <section>
           <h4>Hashlinks</h4>

--- a/index.html
+++ b/index.html
@@ -187,7 +187,12 @@ machine-readable information associated with a <a>verifiable credential</a>.
       <em>This section is non-normative.</em>
 
       <p>
-TBD
+<a>Verification</a> is the process a <a>verifier</a> or <a>holder</a> undergoes
+when presented with a <a>verifiable presentation</a> or
+<a>verifiable credential</a>. <a>Verification</a> includes checking the
+presented item against the <a href="https://www.w3.org/TR/vc-data-model/">core
+data model</a>, and may also include validating the provided proof section and
+checking the item's status.
       </p>
 
       <section>
@@ -206,6 +211,35 @@ the core data model is verified when processing credentials.
 There are many data verification languages, the following approach is one
 that should work for most use cases.
         </p>
+      </section>
+      <section>
+        <h3>Content Integrity</h3>
+        <p>
+Protecting the integrity of content is an important component of verification.
+<a>Verifiers</a> need to have confidence that the content they rely on to
+verify <a>credentials</a> doesn't change without their knowledge. This content
+may include data schemas, identifiers, public keys, etc.
+        </p>
+        <p>
+There are a number of ways to provide content integrity protection. A few of
+them are provided in greater detail below.
+        </p>
+        <section>
+          <h4>Hashlinks</h4>
+
+          <p>
+Hashlink URLs can be used to provide content integrity for links to external
+resources.
+          </p>
+        </section>
+        <section>
+          <h4>Verifiable Data Registries</h4>
+          <p>
+A <a>verifiable data registry</a> can also provide content integrity protection.
+One example of a <a>verifiable data registry</a> which provides content
+integrity protection is a distributed ledger.
+          </p>
+        </section>
       </section>
     </section>
     <section>
@@ -1435,34 +1469,6 @@ the cost of implementation complexity.
           </dd>
         </dl>
 
-      </section>
-
-      <section>
-        <h3>Cryptographic Suites</h3>
-
-        <ul>
-          <li>
-            Design the Cryptographic Suite.
-          </li>
-          <li>
-            Create the JSON-LD Context.
-          </li>
-          <li>
-            Select a publishing location.
-          </li>
-          <li>
-            Implement the Cryptographic Suite and use it.
-          </li>
-        </ul>
-      </section>
-
-      <section>
-        <h3>Hashlinks</h3>
-
-        <p>
-          Hashlink URLs can be used to provide content integrity for links to
-          external resources.
-        </p>
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@ machine-readable information associated with a <a>verifiable credential</a>.
       <em>This section is non-normative.</em>
 
       <p>
-<a>Verification</a> is the process a <a>verifier</a> or <a>holder</a> undergoes
+<a>Verification</a> is the process a <a>verifier</a> or <a>holder</a> performs
 when presented with a <a>verifiable presentation</a> or
 <a>verifiable credential</a>. <a>Verification</a> includes checking the
 presented item against the <a href="https://www.w3.org/TR/vc-data-model/">core
@@ -222,7 +222,7 @@ may include data schemas, identifiers, public keys, etc.
         </p>
         <p>
 There are a number of ways to provide content integrity protection. A few of
-them are provided in greater detail below.
+them are described in greater detail below.
         </p>
         <section>
           <h4>Hashlinks</h4>


### PR DESCRIPTION
This PR adds some text to the Verification section, adds some text to the content integrity section, adds text to the verifiable data registry subsection of the CIP section, and makes the hashlinks section a subsection of the CIP section. (moving the hashlinks section and creating the CIP subsection were part of previous, already merged PRs, but were lost due to rash conflict resolution)
Signed-off-by: Brent <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-imp-guide/pull/40.html" title="Last updated on Aug 15, 2019, 3:33 PM UTC (e4f583c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/40/757905a...brentzundel:e4f583c.html" title="Last updated on Aug 15, 2019, 3:33 PM UTC (e4f583c)">Diff</a>