### PR TITLE
Jwt aud claim

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,8 +319,8 @@ as their own.
 
       <p>
 The following <a>verifiable presentation</a> is for authenticating to
-a website <code>https://example.com</code>. Note that the <code>domain</code>
-value can be any string or URI and the <code>challenge</code> should be a
+a website, <code>https://example.com</code>. Note that the <code>domain</code>
+value can be any string or URI, and the <code>challenge</code> should be a
 randomly generated string.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -320,8 +320,8 @@ as their own.
       <p>
 The following <a>verifiable presentation</a> is for authenticating to
 a website <code>https://example.com</code>. Note that the <code>domain</code>
-value can be any string or URI and the <code>challenge</code> value can be any
-string, typically a randomly generated one.
+value can be any string or URI and the <code>challenge</code> should be a
+randomly generated string.
       </p>
 
 

--- a/index.html
+++ b/index.html
@@ -306,6 +306,46 @@ claims.
     </section>
 
     <section>
+      <h3>Presentations</h3>
+
+      <p>
+<a>Verifiable credentials</a> may be presented to a <a>verifier</a> by
+using a <a>verifiable presentation</a>. A <a>verifiable presentation</a> can
+be targeted to a specific <a>verifier</a> by using a Linked Data Proof
+that includes a <code>domain</code> and <code>challenge</code>. This also
+helps prevent a <a>verifier</a> from reusing a <a>verifiable presentation</a>
+as their own.
+      </p>
+
+      <p>
+The following <a>verifiable presentation</a> is for authenticating to
+a website <code>https://example.com</code>. Note that the <code>domain</code>
+value can be any string or URI.
+      </p>
+
+
+      <pre class="example nohighlight" title="A targeted verifiable presentation">
+{
+"@context": [
+  "https://www.w3.org/2018/credentials/v1"
+],
+"type": "VerifiablePresentation,
+"verifiableCredential": { ... },
+"proof": {
+  "type": "Ed25519Signature2018",
+  "created": "2019-08-13T15:09:00Z",
+  <span class="highlight">"challenge": "d1b23d3...3d23d32d2",
+  "domain": "https://example.com",</span>
+  "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..uyW7Hv
+    VOZ8QCpLJ63wHode0OdgWjsHfJ0O8d8Kfs55dMVEg3C1Z0bYUGV49s8IlTbi3eXsNvM63n
+    vah79E-lAg",
+  "proofPurpose": "authentication"
+}
+      </pre>
+
+    </section>
+
+    <section>
       <h2>Extensions</h2>
 
       <em>This section is non-normative.</em>
@@ -1646,16 +1686,16 @@ also be useful reading for implementers looking to enable progressive trust.
       <em>This section is non-normative.</em>
 
       <p>
-        The W3C Verifiable Claims Working Group has produced a 
-        <a href="https://github.com/w3c/vc-test-suite/">test suite</a> in order 
+        The W3C Verifiable Claims Working Group has produced a
+        <a href="https://github.com/w3c/vc-test-suite/">test suite</a> in order
         for implementers to confirm their conformance with the current specifications.
       </p>
       <p>
-        You can review the <a href="https://w3c.github.io/vc-test-suite/implementations/">current 
+        You can review the <a href="https://w3c.github.io/vc-test-suite/implementations/">current
         draft implementation report</a>, which contains conformance testing results for submitted
         implementations supporting the Verifiable Credentials Data Model specification.
       </p>
     </section>
-  
+
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -320,7 +320,8 @@ as their own.
       <p>
 The following <a>verifiable presentation</a> is for authenticating to
 a website <code>https://example.com</code>. Note that the <code>domain</code>
-value can be any string or URI.
+value can be any string or URI and the <code>challenge</code> value can be any
+string, typically a randomly generated one.
       </p>
 
 

--- a/index.html
+++ b/index.html
@@ -378,7 +378,8 @@ of the <a>verifiable presentation</a>, nor vice versa. We recommend that the
 targeted verifiable presentation using the verifier property">
 {
   "@context": [
-    "https://www.w3.org/2018/credentials/v1"
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credImpGuide/v1"
   ],
   "type": "VerifiablePresentation",
   "verifiableCredential": ["..."],
@@ -399,7 +400,8 @@ targeted verifiable presentation using the JWT aud claim">
   "nonce": "343s$FSFDa-",
   "vp": {
     "@context": [
-      "https://www.w3.org/2018/credentials/v1"
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credImpGuide/v1"
     ],
     "type": "VerifiablePresentation",
     "verifiableCredential": ["..."]

--- a/index.html
+++ b/index.html
@@ -404,7 +404,7 @@ targeted verifiable presentation using the JWT aud claim">
       "https://www.w3.org/2018/credImpGuide/v1"
     ],
     "type": "VerifiablePresentation",
-    "verifiableCredential": ["..."]
+    "verifiableCredential": [" <span class="comment">...</span> "]
   }
 }
       </pre>
@@ -1757,7 +1757,7 @@ also be useful reading for implementers looking to enable progressive trust.
       </p>
       <p>
         You can review the <a href="https://w3c.github.io/vc-test-suite/implementations/">current
-        draft implementation report</a>, which contains conformance testing results for submitted
+        implementation report</a>, which contains conformance testing results for submitted
         implementations supporting the Verifiable Credentials Data Model specification.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -348,6 +348,28 @@ randomly generated string.
     </section>
 
     <section>
+      <h4>Using the JWT aud claim</h3>
+
+      <p>
+The JWT <code>aud</code> <a>claim> name refers to (i.e., identifies) the
+intended audience of the <a>verifiable presentation</a> (i.e., the verifier).
+Consequently this is an alternative to the Linked Data Proof method specified
+above, for the holder to indicate to the recipient of the
+<a>verifiable presentation</a> who the verifier should be.
+      </p>
+      <p>
+The <a href="https://w3c.github.io/vc-data-model/">data model specification</a>
+provides no guidance of how to transform this JWT <a>claim</a> into a property
+of the <a> verifiable presentation</a> and vice versa. 
+<a href="https://tools.ietf.org/html/rfc7519">RFC 7519</a> defines 
+<code>aud</code> as "an array of case-sensitive strings, each containing a 
+StringOrURI value". We recommend that this is restricted to a single URI value,
+equal to the URI of the verifier. We further recommend that the JWT <code>aud</code>
+<a>claim> is mapped into the <a>verifiable presentation> <code>domain</code> property.
+   </p>
+    </section>
+
+    <section>
       <h2>Extensions</h2>
 
       <em>This section is non-normative.</em>

--- a/index.html
+++ b/index.html
@@ -370,9 +370,42 @@ of the intended verifier.
 The <a href="https://w3c.github.io/vc-data-model/">data model specification</a>
 provides no guidance of how to transform this JWT <a>claim</a> into a property
 of the <a>verifiable presentation</a>, nor vice versa. We recommend that the
-<code>aud</code> JWT <a>claim</a> be mapped to the <code>domain</code> property
-of the <a>verifiable presentation</a>.
+<code>aud</code> JWT <a>claim</a> be mapped to the <code>verifier</code> 
+<a>property</a> of the <a>verifiable presentation</a>.
       </p>
+
+      <pre class="example nohighlight" title="An example of a
+targeted verifiable presentation using the verifier property">
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "type": "VerifiablePresentation",
+  "verifiableCredential": ["..."],
+  "holder": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+  "verifier": "https://some.verifier.com"
+}
+      </pre>
+
+      <pre class="example nohighlight" title="An example JWT for a
+targeted verifiable presentation using the JWT aud claim">
+{
+  "iss": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+  "jti": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
+  "aud": "https://some.verifier.com",
+  "nbf": 1541493724,
+  "iat": 1541493724,
+  "exp": 1573029723,
+  "nonce": "343s$FSFDa-",
+  "vp": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1"
+    ],
+    "type": "VerifiablePresentation",
+    "verifiableCredential": ["..."]
+  }
+}
+      </pre>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -326,20 +326,21 @@ value can be any string or URI.
 
       <pre class="example nohighlight" title="A targeted verifiable presentation">
 {
-"@context": [
-  "https://www.w3.org/2018/credentials/v1"
-],
-"type": "VerifiablePresentation,
-"verifiableCredential": { ... },
-"proof": {
-  "type": "Ed25519Signature2018",
-  "created": "2019-08-13T15:09:00Z",
-  <span class="highlight">"challenge": "d1b23d3...3d23d32d2",
-  "domain": "https://example.com",</span>
-  "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..uyW7Hv
-    VOZ8QCpLJ63wHode0OdgWjsHfJ0O8d8Kfs55dMVEg3C1Z0bYUGV49s8IlTbi3eXsNvM63n
-    vah79E-lAg",
-  "proofPurpose": "authentication"
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "type": "VerifiablePresentation,
+  "verifiableCredential": { ... },
+  "proof": {
+    "type": "Ed25519Signature2018",
+    "created": "2019-08-13T15:09:00Z",
+    <span class="highlight">"challenge": "d1b23d3...3d23d32d2",
+    "domain": "https://example.com",</span>
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..uyW7Hv
+      VOZ8QCpLJ63wHode0OdgWjsHfJ0O8d8Kfs55dMVEg3C1Z0bYUGV49s8IlTbi3eXsNvM63n
+      vah79E-lAg",
+    "proofPurpose": "authentication"
+  }
 }
       </pre>
 

--- a/index.html
+++ b/index.html
@@ -352,21 +352,27 @@ randomly generated string.
 
       <p>
 The JWT <code>aud</code> <a>claim</a> name refers to (i.e., identifies) the
-intended audience of the <a>verifiable presentation</a> (i.e., the verifier).
+intended audience of the <a>verifiable presentation</a> (i.e., the verifier(s)).
 Consequently this is an alternative to the Linked Data Proof method specified
-above, for the holder to indicate to the recipient of the
-<a>verifiable presentation</a> who the verifier should be.
+above. It lets the <a>holder</a> indicate which <a>verifier(s)</a> it allows
+to verify the <a>verifiable presentation</a>. Any JWT-compliant <a>verifier</a>
+that is not identified in the <code>aud</code> is required to
+reject the JWT (see <a href="https://tools.ietf.org/html/rfc7519">RFC 7519</a>).
+      </p>
+      <p>
+<a href="https://tools.ietf.org/html/rfc7519">RFC 7519</a> defines
+<code>aud</code> as "an array of case-sensitive strings, each containing a
+<code>StringOrURI</code> value". For use in a <a>verifiable presentation</a>,
+we recommend that this be restricted to a single URI value, equal to the URI
+of the intended verifier.
       </p>
       <p>
 The <a href="https://w3c.github.io/vc-data-model/">data model specification</a>
 provides no guidance of how to transform this JWT <a>claim</a> into a property
-of the <a> verifiable presentation</a> and vice versa. 
-<a href="https://tools.ietf.org/html/rfc7519">RFC 7519</a> defines 
-<code>aud</code> as "an array of case-sensitive strings, each containing a 
-StringOrURI value". We recommend that this is restricted to a single URI value,
-equal to the URI of the verifier. We further recommend that the JWT <code>aud</code>
-<a>claim> is mapped into the <a>verifiable presentation> <code>domain</code> property.
-   </p>
+of the <a>verifiable presentation</a>, nor vice versa. We recommend that the
+<code>aud</code> JWT <a>claim</a> be mapped to the <code>domain</code> property
+of the <a>verifiable presentation</a>.
+      </p>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -363,13 +363,13 @@ reject the JWT (see <a href="https://tools.ietf.org/html/rfc7519">RFC 7519</a>).
 <a href="https://tools.ietf.org/html/rfc7519">RFC 7519</a> defines
 <code>aud</code> as "an array of case-sensitive strings, each containing a
 <code>StringOrURI</code> value". For use in a <a>verifiable presentation</a>,
-we recommend that this be restricted to a single URI value, equal to the URI
+we strongly suggest that this be restricted to a single URI value, equal to the URI
 of the intended verifier.
       </p>
       <p>
 The <a href="https://w3c.github.io/vc-data-model/">data model specification</a>
 provides no guidance of how to transform this JWT <a>claim</a> into a property
-of the <a>verifiable presentation</a>, nor vice versa. We recommend that the
+of the <a>verifiable presentation</a>, nor vice versa. We strongly suggest that the
 <code>aud</code> JWT <a>claim</a> be mapped to the <code>verifier</code> 
 <a>property</a> of the <a>verifiable presentation</a>.
       </p>

--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@ randomly generated string.
       <h4>Using the JWT aud claim</h3>
 
       <p>
-The JWT <code>aud</code> <a>claim> name refers to (i.e., identifies) the
+The JWT <code>aud</code> <a>claim</a> name refers to (i.e., identifies) the
 intended audience of the <a>verifiable presentation</a> (i.e., the verifier).
 Consequently this is an alternative to the Linked Data Proof method specified
 above, for the holder to indicate to the recipient of the

--- a/index.html
+++ b/index.html
@@ -352,7 +352,7 @@ randomly generated string.
 
       <p>
 The JWT <code>aud</code> <a>claim</a> name refers to (i.e., identifies) the
-intended audience of the <a>verifiable presentation</a> (i.e., the verifier(s)).
+intended audience of the <a>verifiable presentation</a> (i.e., the <a>verifier(s)</a>).
 Consequently this is an alternative to the Linked Data Proof method specified
 above. It lets the <a>holder</a> indicate which <a>verifier(s)</a> it allows
 to verify the <a>verifiable presentation</a>. Any JWT-compliant <a>verifier</a>
@@ -379,10 +379,10 @@ targeted verifiable presentation using the verifier property">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credImpGuide/v1"
+    "https://www.w3.org/2019/credentials/v1.1"
   ],
   "type": "VerifiablePresentation",
-  "verifiableCredential": ["..."],
+  "verifiableCredential": [" <span class="comment">...</span> "],
   "holder": "did:example:ebfeb1f712ebc6f1c276e12ec21",
   "verifier": "https://some.verifier.com"
 }


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 403 Forbidden :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 27, 2019, 3:11 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fvc-imp-guide%2Fpull%2F43%2F9b2ecf9.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fvc-imp-guide%2Fpull%2F43.html)

```

<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US">
<head><title>HTML Diff service</title>
<link rel="stylesheet" href="http://www.w3.org/StyleSheets/base" />
</head>
<body>

<p><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" alt="W3C"/></a> <a href="http://www.w3.org/2003/Editors">W3C Editors homepage</a></p>

<h1>Create Diff between HTML pages</h1>

<p style='color:#FF0000'>An error (403 Forbidden) occured trying to get <a href='https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/pull/43/9b2ecf9.html'>https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/pull/43/9b2ecf9.html</a>.</p>

<form method="GET">
<p>Address of reference document: <input name="doc1" type="url" value="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/pull/43/9b2ecf9.html" style="width:100%"/></p>
<p>Address of new document: <input name="doc2" value="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/pull/43.html"  style="width:100%"/></p>
<p><input type="submit" value="get Diff"/></p>
</form>

<p><strong>Tip</strong>: if the document uses the W3C convention on linking to its previous version, you can specify only the address of the new document — the previous link will be automatically detected.</p>
<h2>Diff markings</h2>
<p>This service relies on <a href="https://www.gnu.org/software/diffutils/">GNU diff</a>. The found differences are roughly marked as follow:
<ul>
<li>deleted text is shown in pink with down-arrows (as styled for a &lt;del> element)</li>
<li>where there is replacement, it’s shown in green with bi-directional arrows,</li>
<li>where there is newly inserted text, it’s yellow with up arrows (&lt;ins> element)</li>
</ul>
<address>
script $Revision$ of $Date$<br />
by <a href="http://www.w3.org/People/Dom/">Dominique Hazaël-Massieux</a><br />based on <a href="https://dev.w3.org/cvsweb/2009/htmldiff/htmldiff.pl">Shane McCarron’ Perl script</a> wrapped in a <a href="http://dev.w3.org/cvsweb/2009/htmldiff/">Python CGI</a>
</address>
</body>
</html>


```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/vc-imp-guide%2343.)._
</details>
