### PR TITLE
fixes #29; do not copy non-JSON elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@ can issue one of the <a>credentials</a> shown below. In the first example, the
   }</span>,
   "issuer": "https://example.com/people#me",
   "issuanceDate": "2017-12-05T14:27:42Z",
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
       </pre>
 
@@ -324,7 +324,7 @@ can issue one of the <a>credentials</a> shown below. In the first example, the
   }</span>,
   "issuer": "https://example.com/people#me",
   "issuanceDate": "2017-12-05T14:27:42Z",
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
       </pre>
 
@@ -568,7 +568,7 @@ specification and then bring in the terms defined by schema.org:
               "https://www.w3.org/2018/credentials/v1",
               "http://schema.org"
             ]</span>,
-            ...
+            <span class="comment">...</span>
             "credentialSubject": {
               "type": "Person",
               "address": {
@@ -580,7 +580,7 @@ specification and then bring in the terms defined by schema.org:
                 "addressCountry": "US"
               }
             },
-            ...
+            <span class="comment">...</span>
           }
         </pre>
 
@@ -738,7 +738,7 @@ wishes to issue an <em>ExampleAddressCredential</em>!
                 "addressCountry": "US"
               }
             },
-            "proof": { ... }
+            "proof": { <span class="comment">...</span> }
           }
         </pre>
 
@@ -765,7 +765,7 @@ applications:
               "https://www.w3.org/2018/credentials/examples/v1"
             ]</span>,
             "id": "http://example.edu/credentials/1872",
-            ...
+            <span class="comment">...</span>
         </pre>
 
         <p>


### PR DESCRIPTION
This PR fixes #29 by wrapping non-JSON elements in examples within a `<span class="comment">` tag.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/pull/53.html" title="Last updated on Aug 27, 2019, 8:17 AM UTC (a697072)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/53/950a115...a697072.html" title="Last updated on Aug 27, 2019, 8:17 AM UTC (a697072)">Diff</a>