### PR TITLE
resolves #22; re. risks of evolving schema.org vocab

### DIFF
--- a/index.html
+++ b/index.html
@@ -486,7 +486,7 @@ it using JSON-LD.
         </p>
 
         <p>
-Please note that shema.org is developed incrementally, meaning that the definition
+Please note that schema.org is developed incrementally, meaning that the definition
 of a term today may differ from a future definition, or even be removed. Although
 schema.org developers encourage using the latest release, as in the simple
 non-versioned schema.org URLs such as </code>http://schema.org/Place</code> in

--- a/index.html
+++ b/index.html
@@ -489,11 +489,15 @@ it using JSON-LD.
 Please note that schema.org is developed incrementally, meaning that the definition
 of a term today may differ from a future definition, or even be removed. Although
 schema.org developers encourage using the latest release, as in the simple
-non-versioned schema.org URLs such as </code>http://schema.org/Place</code> in
+non-versioned schema.org URLs such as <code>http://schema.org/Place</code> in
 structured data applications, there are times in which more precise versioning is
 important. Schema.org also provides dated snapshots of each release, including both
 human and machine readable definitions of the schema.org core vocabulary. These are
 linked from the <a href="https://schema.org/docs/releases.html">releases page</a>.
+For instance, instead of the unversioned URI <code>http://schema.org/Place</code>,
+you might use the versioned URI
+<code>https://schema.org/version/3.9/schema-all.html#term_Place</code>.
+
 In addition, the <code>schemaVersion</code> property has been defined to provide a
 way for documents to indicate the specific intended version of schema.org's
 definitions.

--- a/index.html
+++ b/index.html
@@ -487,7 +487,7 @@ it using JSON-LD.
 
         <p>
 Please note that shema.org is developed incrementally, meaning that the definition
-of a term today may differ from a future definition, or even removed. Although
+of a term today may differ from a future definition, or even be removed. Although
 schema.org developers encourage using the latest release, as in the simple
 non-versioned schema.org URLs such as </code>http://schema.org/Place</code> in
 structured data applications, there are times in which more precise versioning is

--- a/index.html
+++ b/index.html
@@ -486,6 +486,20 @@ it using JSON-LD.
         </p>
 
         <p>
+Please note that shema.org is developed incrementally, meaning that the definition
+of a term today may differ from a future definition, or even removed. Although
+schema.org developers encourage using the latest release, as in the simple
+non-versioned schema.org URLs such as </code>http://schema.org/Place</code> in
+structured data applications, there are times in which more precise versioning is
+important. Schema.org also provides dated snapshots of each release, including both
+human and machine readable definitions of the schema.org core vocabulary. These are
+linked from the <a href="https://schema.org/docs/releases.html">releases page</a>.
+In addition, the <code>schemaVersion</code> property has been defined to provide a
+way for documents to indicate the specific intended version of schema.org's
+definitions.
+        </p>
+
+        <p>
 Using the schema.org vocabulary and JSON-LD we can express a person's address
 like so:
         </p>


### PR DESCRIPTION
This PR fixes #22. I've added some text mentioning the use of `schema.org` and its mutable nature. Are you OK with this text, @TallTed?

I would like to avoid starting a philosophical debate regarding vocabulary immutability in RDF, and focus instead on just the caveats of schema.org. I believe @dlongley covered it sufficiently in the paragraph above the one I just added.

>If we are going to use someone else's vocabulary, we will want to make sure it
is stable and unlikely to change in any significant way. There may even be
technologies that we can make use of that store immutable vocabularies that
we can reference, but those are not the focus of this example.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/pull/54.html" title="Last updated on Aug 27, 2019, 1:59 PM UTC (af50d9f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/54/950a115...af50d9f.html" title="Last updated on Aug 27, 2019, 1:59 PM UTC (af50d9f)">Diff</a>