### PR TITLE
Fix a broken link to a paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -2010,7 +2010,7 @@ credential to be revealed.
 <b>Selective Disclosure Signatures</b> - Certain signature schemes natively
 support selective disclosure of <a>verifiable credential</a> claims. One
 example of these is
-<a href="https://groups.csail.mit.edu/cis/pubs/lysyanskaya/cl02b.pdf">Camenisch-Lysyanskaya
+<a href="https://cs.brown.edu/~alysyans/papers/camlys02b.pdf">Camenisch-Lysyanskaya
 signatures</a>. Such Signatures allow a <a>holder</a> to disclose only those
 claims which need to be revealed to a <a>verifier</a>, rather than requiring
 all of the credential's claims to be revealed.
@@ -2051,7 +2051,7 @@ over 18 without revealing their birthdates.
         <p>
 Certain signature types enable predicate proofs by allowing claims from a
 standard <a>verifiable credential</a> to be presented as predicates. For
-example, a <a href="https://groups.csail.mit.edu/cis/pubs/lysyanskaya/cl02b.pdf">
+example, a <a href="https://cs.brown.edu/~alysyans/papers/camlys02b.pdf">
 Camenisch-Lysyanskaya signed</a> <a>verifiable credential</a> that contains a
 <code>credentialSubject</code> with a <code>birthdate</code> property may
 be included in a <a>verifiable presentation</a> as a derived credential that


### PR DESCRIPTION
The link to the Camenisch–Lysyanskaya signature paper was broken.

Replace it with an up-to-date link to the file hosted on the researcher’s personal website.
(They have moved from MIT to Brown a long time ago.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kirelagin/vc-imp-guide/pull/60.html" title="Last updated on Jun 9, 2021, 11:08 PM UTC (e18daf6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/60/92b36b0...kirelagin:e18daf6.html" title="Last updated on Jun 9, 2021, 11:08 PM UTC (e18daf6)">Diff</a>