### PR TITLE
Migrate Subject-Holder Relationships to VC Implementation Guide.

### DIFF
--- a/diagrams/subject-ne-holder.svg
+++ b/diagrams/subject-ne-holder.svg
@@ -1,0 +1,60 @@
+<svg version="1.1" viewBox="0 0 960 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<defs>
+		<marker id="arrow" viewBox="0 0 6 4" refX="1" refY="2" fill="#000"
+      markerWidth="6" markerHeight="4" orient="auto">
+    <path d="M0 0v4l6 -2z" />
+    </marker>
+		<style><![CDATA[
+			path {stroke-width:1px;marker-end: url(#arrow)}
+			text {fill:#000;font-size:18px;font-family:sans-serif}
+			#background {fill:#fff;width:100%;height:100%;stroke:none}
+		]]></style>
+		<symbol id="decision">
+			<path stroke="#0c0" d="m70 5l-60 60"/>
+			<text y="45">Yes</text>
+			<path stroke="#f00" d="m80 5l60 60"/>
+			<text x="120" y="45">No</text>
+    </symbol>
+	</defs>
+	<rect id="background"/>
+
+<text x="220" y="20">Subject Present?</text>
+<use href="#decision" x="220" y="20"/>
+
+<text x="320" y="115">Bearer Credential</text>
+
+<text x="115" y="115">Subject = Holder?</text>
+<use href="#decision" x="125" y="115"/>
+
+<text y="210">Most common use case</text>
+
+<text x="220" y="210">Credential uniquely identifies subject?</text>
+<use href="#decision" x="220" y="210"/>
+
+<text x="95" y="305">Irrelevant who Holder is</text>
+
+<text x="315" y="305">Subject passes VC to Holder?</text>
+<use href="#decision" x="315" y="305"/>
+
+<text x="105" y="400">e.g. Power of Attorney, employee</text>
+
+<text x="410" y="400">Issuer indepenently authorises Holder?</text>
+<use href="#decision" x="410" y="400"/>
+
+<text x="285" y="495">e.g. Law enforcement</text>
+
+<text x="505" y="495">Holder acts for Subject?</text>
+<use href="#decision" x="505" y="495"/>
+
+<text x="320" y="590">e.g. pet owner, travel agent</text>
+
+<text x="600" y="590">Holder acts for Verifier?</text>
+<use href="#decision" x="600" y="590"/>
+
+<text x="250" y="685">e.g. recruiter passing on VC of applicant to employer</text>
+
+<text x="700" y="685">
+	<tspan>Random holder, no relation to</tspan>
+	<tspan x="700" y="705">Subject, Issuer, nor Verifier.</tspan>
+</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -350,6 +350,452 @@ protection mechanism, as previously discussed).
     </section>
   </section>
 
+  <section class="informative">
+    <h2>Subject-Holder Relationships</h2>
+
+    <p>
+This section describes possible relationships between a <a>subject</a> and a
+<a>holder</a> and how the Verifiable Credentials Data Model expresses these
+relationships. The following diagram illustrates these relationships, with the
+subsequent sections describing how each of these relationships are handled in
+the data model.
+    </p>
+
+    <figure>
+      <img style="margin: auto; display: block; width: 75%;"
+        src="diagrams/subject-ne-holder.svg" alt="Long decision tree
+        from top to bottom.  For the first question, 'Subject
+        Present?', No means Bearer Credential and Yes points to the
+        rest of the tree.  From this point on until the very end,
+        each Yes points to an answer and each No points to another
+        question.  The first question here is 'Subject = Holder?',
+        with Yes meaning Most Common Use Case.  If No, 'Credential
+        Uniquely Identifies Subject?' with Yes meaning Irrelevant who
+        Holder is.  If No, 'Subject Passes VC to Holder?' with Yes
+        meaning, e.g., Power of Attorney, Employee.  If No, 'Issuer
+        Independently Authorizes Holder?' with Yes meaning, e.g., Law
+        Enforcement.  If No, 'Holder Acts for Subject?' with Yes
+        meaning, e.g., Parent, Pet Owner, Travel Agent.  If No,
+        'Holder Acts for Verifier?' with Yes meaning, e.g., Recruiter
+        passing on VC of job applicant to employer and No meaning
+        'Random Holder with no relationship to Subject, Issuer or Verifier">
+      <figcaption style="text-align: center;">
+Subject-Holder Relationships in Verifiable Credentials.
+      </figcaption>
+    </figure>
+
+    <section class="informative">
+      <h3>Subject is the Holder</h3>
+
+      <p>
+The most common relationship is when a <a>subject</a> is the <a>holder</a>. In
+this case, a <a>verifier</a> can easily deduce that a <a>subject</a> is the
+<a>holder</a> if the <a>verifiable presentation</a> is digitally signed by the
+<a>holder</a> and all contained <a>verifiable credentials</a> are about a
+<a>subject</a> that can be identified to be the same as the <a>holder</a>.
+      </p>
+
+      <p>
+If only the <code>credentialSubject</code> is allowed to insert a
+<a>verifiable credential</a> into a <a>verifiable presentation</a>, the
+<a>issuer</a> can insert the <code>nonTransferable</code> <a>property</a> into
+the <a>verifiable credential</a>, as described below.
+      </p>
+
+      <section class="informative">
+        <h4>nonTransferable Property</h4>
+
+        <p>
+The <code>nonTransferable</code> <a>property</a> indicates that a
+<a>verifiable credential</a> must only be encapsulated into a
+<a>verifiable presentation</a> whose proof was issued by the
+<code>credentialSubject</code>. A <a>verifiable presentation</a> that contains
+a <a>verifiable credential</a> containing the <code>nonTransferable</code>
+<a>property</a>, whose proof creator is not the <code>credentialSubject</code>,
+is invalid.
+        </p>
+
+        <pre class="example nohighlight" title="Usage of the nonTransferable property">
+{
+"@context": [
+  "https://www.w3.org/2018/credentials/v1",
+  "https://www.w3.org/2018/credentials/examples/v1"
+],
+"id": "http://example.edu/credentials/3732",
+"type": ["VerifiableCredential", "ProofOfAgeCredential"],
+"issuer": "https://example.edu/issuers/14",
+"issuanceDate": "2010-01-01T19:23:24Z",
+"credentialSubject": {
+  "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+  "ageOver": 21
+  },
+"nonTransferable": true,
+"proof": { ..
+"verificationMethod": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+... }
+}
+        </pre>
+      </section>
+    </section>
+
+    <section class="informative">
+      <h3>Credential Uniquely Identifies a Subject</h3>
+
+      <p>
+In this case, the <code>credentialSubject</code> <a>property</a> might contain
+multiple <a>properties</a>, each providing an aspect of a description of the
+<a>subject</a>, which combine together to unambiguously identify the
+<a>subject</a>. Some use cases might not require the <a>holder</a> to be
+identified at all, such as checking to see if a doctor (the <a>subject</a>) is
+board-certified. Other use cases might require the <a>verifier</a> to use
+out-of-band knowledge to determine the relationship between the <a>subject</a>
+and the <a>holder</a>.
+      </p>
+
+      <pre class="example nohighlight" title="A credential uniquely identifying a subject">
+{
+"@context": ["https://www.w3.org/2018/credentials/v1", "https://schema.org/"]
+"id": "http://example.edu/credentials/332",
+"type": ["VerifiableCredential", "IdentityCredential"],
+"issuer": "https://example.edu/issuers/4",
+"issuanceDate": "2017-02-24T19:73:24Z",
+"credentialSubject": {
+  "name": "J. Doe",
+  "address": {
+    "streetAddress": "10 Rue de Chose",
+    "postalCode": "98052",
+    "addressLocality": "Paris",
+    "addressCountry": "FR"
+  },
+  "birthDate": "1989-03-15"
+  ...
+},
+"proof": { <span class="comment">...</span> }
+}
+      </pre>
+
+      <p>
+The example above uniquely identifies the <a>subject</a> using the name,
+address, and birthdate of the individual.
+      </p>
+    </section>
+
+    <section class="informative">
+      <h3>Subject Passes the Verifiable Credential to a Holder</h3>
+
+      <p>
+Usually <a>verifiable credentials</a> are presented to <a>verifiers</a> by the
+<a>subject</a>. However, in some cases, the <a>subject</a> might need to pass the
+whole or part of a <a>verifiable credential</a> to another <a>holder</a>. For
+example, if a patient (the <a>subject</a>) is too ill to take a prescription
+(the <a>verifiable credential</a>) to the pharmacist (the <a>verifier</a>), a
+friend might take the prescription in to pick up the medication.
+      </p>
+
+      <p>
+The data model allows for this by letting the <a>subject</a> issue a new
+<a>verifiable credential</a> and give it to the new <a>holder</a>, who can
+then present both <a>verifiable credentials</a> to the <a>verifier</a>.
+However, the content of this second <a>verifiable credential</a> is likely to
+be application-specific, so this specification cannot standardize the contents
+of this second <a>verifiable credential</a>. Nevertheless, a non-normative
+example is provided in Appendix
+<a href="#subject-passes-a-verifiable-credential-to-someone-else"></a>.
+      </p>
+    </section>
+
+    <section class="informative">
+      <h3>Holder Acts on Behalf of the Subject</h3>
+
+      <p>
+The Verifiable Credentials Data Model supports the <a>holder</a> acting on
+behalf of the <a>subject</a> in at least the following ways. The:
+      </p>
+
+      <ul>
+        <li>
+<a>Issuer</a> can include the relationship between the <a>holder</a> and
+the <a>subject</a> in the <code>credentialSubject</code> <a>property</a>.
+        </li>
+        <li>
+<a>Issuer</a> can express the relationship between the <a>holder</a> and
+the <a>subject</a> by issuing a new <a>verifiable credential</a>, which the
+<a>holder</a> utilizes.
+        </li>
+        <li>
+<a>Subject</a> can express their relationship with the <a>holder</a> by
+issuing a new <a>verifiable credential</a>, which the <a>holder</a> utilizes.
+        </li>
+      </ul>
+
+      <p>
+The mechanisms listed above describe the relationship between the
+<a>holder</a> and the <a>subject</a> and helps the <a>verifier</a> decide
+whether the relationship is sufficiently expressed for a given use case.
+      </p>
+
+      <p class="note">
+The additional mechanisms the <a>issuer</a> or the <a>verifier</a> uses to
+verify the relationship between the <a>subject</a> and the <a>holder</a> are
+outside the scope of this specification.
+      </p>
+
+      <pre class="example nohighlight" title="The relationship property in a child's credential">{
+"@context": [
+  "https://www.w3.org/2018/credentials/v1",
+  "https://www.w3.org/2018/credentials/examples/v1"
+],
+"id": "http://example.edu/credentials/3732",
+"type": ["VerifiableCredential", "AgeCredential", "RelationshipCredential"],
+"issuer": "https://example.edu/issuers/14",
+"issuanceDate": "2010-01-01T19:23:24Z",
+"credentialSubject": {
+  "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+  "ageUnder": 16,
+  "parent": {
+    "id": "did:example:ebfeb1c276e12ec211f712ebc6f",
+    "type": "Mother"
+  }
+},
+"proof": { <span class="comment">...</span> }  <span class="comment">// the proof is generated by the DMV</span>
+}
+      </pre>
+
+      <p>
+In the example above, the <a>issuer</a> expresses the relationship between the
+child and the parent such that a <a>verifier</a> would most likely accept the
+<a>credential</a> if it is provided by the child or the parent.
+      </p>
+
+      <pre class="example nohighlight" title="A relationship credential issued to a parent">{
+"@context": [
+  "https://www.w3.org/2018/credentials/v1",
+  "https://www.w3.org/2018/credentials/examples/v1"
+],
+"id": "http://example.edu/credentials/3732",
+"type": ["VerifiableCredential", "RelationshipCredential"],
+"issuer": "https://example.edu/issuers/14",
+"issuanceDate": "2010-01-01T19:23:24Z",
+"credentialSubject": {
+  "id": "did:example:ebfeb1c276e12ec211f712ebc6f",
+  "child": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "type": "Child"
+  }
+},
+"proof": { <span class="comment">...</span> } <span class="comment">// the proof is generated by the DMV</span>
+}
+      </pre>
+
+      <p>
+In the example above, the <a>issuer</a> expresses the relationship between the
+child and the parent in a separate <a>credential</a> such that a
+<a>verifier</a> would most likely accept any of the child's <a>credentials</a>
+if they are provided by the child or if the <a>credential</a> above is
+provided with any of the child's <a>credentials</a>.
+      </p>
+
+      <pre class="example nohighlight" title="A relationship credential issued by a child">{
+"@context": [
+  "https://www.w3.org/2018/credentials/v1",
+  "https://www.w3.org/2018/credentials/examples/v1"
+],
+"id": "http://example.org/credentials/23894",
+"type": ["VerifiableCredential", "RelationshipCredential"],
+"issuer": "http://example.org/credentials/23894",
+"issuanceDate": "2010-01-01T19:23:24Z",
+"credentialSubject": {
+  "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+  "parent": {
+    "id": "did:example:ebfeb1c276e12ec211f712ebc6f",
+    "type": "Mother"
+  }
+},
+"proof": { <span class="comment">...</span> } <span class="comment">// the proof is generated by the child</span>
+}
+      </pre>
+
+      <p>
+In the example above, the child expresses the relationship between the child and
+the parent in a separate <a>credential</a> such that a <a>verifier</a> would
+most likely accept any of the child's <a>credentials</a> if the
+<a>credential</a> above is provided.
+      </p>
+
+      <p>
+Similarly, the strategies described in the examples above can be used for many
+other types of use cases, including power of attorney, pet ownership, and
+patient prescription pickup.
+      </p>
+    </section>
+
+    <section class="informative">
+      <h3>Subject Passes a Verifiable Credential to Someone Else</h3>
+
+      <p>
+When a <a>subject</a> passes a <a>verifiable credential</a> to another
+<a>holder</a>, the <a>subject</a> might issue a new <a>verifiable credential</a>
+to the <a>holder</a> in which the:
+      </p>
+
+      <ul>
+        <li>
+<a>Issuer</a> is the <a>subject</a>.
+        </li>
+        <li>
+<a>Subject</a> is the <a>holder</a> to whom the <a>verifiable credential</a> is
+being passed.
+        </li>
+        <li>
+<a>Claim</a> contains the <a>properties</a> being passed on.
+        </li>
+      </ul>
+
+      <p>
+The <a>holder</a> can now create a <a>verifiable presentation</a> containing
+these two <a>verifiable credentials</a> so that the <a>verifier</a> can
+<a>verify</a> that the <a>subject</a> gave the original
+<a>verifiable credential</a> to the <a>holder</a>.
+      </p>
+
+      <pre class="example nohighlight" title="A holder presenting a
+verifiable credential that was passed to it by the subject">
+{
+"@context": [
+  "https://www.w3.org/2018/credentials/v1",
+  "https://www.w3.org/2018/credentials/examples/v1"
+],
+"id": "https://example.com/VP/0987654321",
+"type": ["VerifiablePresentation"],
+"verifiableCredential": [
+  {
+   "@context": [
+     "https://www.w3.org/2018/credentials/v1",
+     "https://www.w3.org/2018/credentials/examples/v1"
+    ],
+    "id": "http://pharma.example.com/credentials/3732",
+    "type": ["VerifiableCredential", "PrescriptionCredential"],
+    "issuer": "https://pharma.example.com/issuer/4",
+    "issuanceDate": "2010-01-01T19:23:24Z",
+    "credentialSubject": {
+      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+      "prescription": {....}
+    },
+    "credentialStatus": {
+      "id": "https://pharma.example.com/credentials/status/3#94567",
+      "type": "RevocationList2020Status",
+      "revocationListIndex": "94567",
+      "revocationListCredential": "https://pharma.example.com/credentials/status/3"
+    },
+    "proof": {....}
+  },
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
+    ],
+    "id": "https://example.com/VC/123456789",
+    "type": ["VerifiableCredential", "PrescriptionCredential"],
+    "issuer": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "issuanceDate": "2010-01-03T19:53:24Z",
+    "credentialSubject": {
+      "id": "did:example:76e12ec21ebhyu1f712ebc6f1z2",
+      "prescription": {....}
+    },
+    "proof": {
+      "type": "RsaSignature2018",
+      "created": "2018-06-17T10:03:48Z",
+      "proofPurpose": "assertionMethod",
+      "jws": "pYw8XNi1..Cky6Ed=",
+      "verificationMethod": "did:example:ebfeb1f712ebc6f1c276e12ec21/keys/234"
+    }
+  }
+],
+"proof": [{
+  "type": "RsaSignature2018",
+  "created": "2018-06-18T21:19:10Z",
+  "proofPurpose": "authentication",
+  "verificationMethod": "did:example:76e12ec21ebhyu1f712ebc6f1z2/keys/2",
+  "challenge": "c0ae1c8e-c7e7-469f-b252-86e6a0e7387e",
+  "jws": "BavEll0/I1..W3JT24="
+}]
+}
+      </pre>
+
+      <p>
+In the above example, a patient (the original <a>subject</a>) passed a
+prescription (the original <a>verifiable credential</a>) to a friend, and
+issued a new <a>verifiable credential</a> to the friend, in which the friend is
+the <a>subject</a>, the <a>subject</a> of the original
+<a>verifiable credential</a> is the <a>issuer</a>, and the <a>credential</a> is
+a copy of the original prescription.
+      </p>
+    </section>
+
+    <section class="informative">
+      <h3>Issuer Authorizes Holder</h3>
+
+      <p>
+When an <a>issuer</a> wants to authorize a <a>holder</a> to possess a
+<a>credential</a> that describes a <a>subject</a> who is not the <a>holder</a>,
+and the <a>holder</a> has no known relationship with the <a>subject</a>, then
+the <a>issuer</a> might insert the relationship of the <a>holder</a> to itself
+into the <a>subject's</a> <a>credential</a>.
+      </p>
+
+      <p class="note">
+Verifiable credentials are not an authorization framework and therefore
+delegation is outside the scope of this specification. However, it is understood
+that verifiable credentials are likely to be used to build authorization and
+delegation systems. The following is one approach that might be appropriate for
+some use cases.
+      </p>
+
+      <pre class="example nohighlight" title="A credential issued to a
+holder who is not the (only) subject of the credential, who has no relationship with
+the subject of the credential, but who has a relationship with the issuer">
+
+{
+"@context": [
+  "https://www.w3.org/2018/credentials/v1",
+  "https://www.w3.org/2018/credentials/examples/v1"
+],
+"id": "http://example.edu/credentials/3732",
+"type": ["VerifiableCredential", "NameAndAddress"],
+"issuer": "https://example.edu/issuers/14",
+"holder": {
+  "type": "LawEnforcement",
+  "id": "did:example:ebfeb1276e12ec21f712ebc6f1c"
+},
+"issuanceDate": "2010-01-01T19:23:24Z",
+"credentialSubject": {
+  "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+  "name": "Mr John Doe",
+  "address": "10 Some Street, Anytown, ThisLocal, Country X"
+},
+"proof": {
+  "type": "RsaSignature2018",
+  "created": "2018-06-17T10:03:48Z",
+  "proofPurpose": "assertionMethod",
+  "verificationMethod": "https://example.edu/issuers/14/keys/234",
+  "jws": "pY9...Cky6Ed = "
+}
+}
+      </pre>
+    </section>
+
+    <section class="informative">
+      <h3>Holder Acts on Behalf of the Verifier, or has no Relationship with
+the Subject, Issuer, or Verifier</h3>
+
+      <p>
+The Verifiable Credentials Data Model currently does not support either of
+these scenarios. It is for further study how they might be supported.
+      </p>
+    </section>
+
+  </section>
+
     <section>
       <h2>Disputes</h2>
 
@@ -511,7 +957,7 @@ of the intended verifier.
 The <a href="https://w3c.github.io/vc-data-model/">data model specification</a>
 provides no guidance of how to transform this JWT <a>claim</a> into a property
 of the <a>verifiable presentation</a>, nor vice versa. We strongly suggest that the
-<code>aud</code> JWT <a>claim</a> be mapped to the <code>verifier</code> 
+<code>aud</code> JWT <a>claim</a> be mapped to the <code>verifier</code>
 property of the <a>verifiable presentation</a>.
       </p>
 
@@ -944,7 +1390,7 @@ and its <code>credentialSubject</code>. Implementers may wish to extend a
 properties that are new (e.g., <code>drivingLicenseNumber</code>,
 <code>mySpecialProperty</code> or that are already registered with IANA
 as JWT <a>claim</a> names (e.g., <code>given_name</code>.
-<code>phone_number_verified</code>. 
+<code>phone_number_verified</code>.
       </p>
       <p>
 As the [[[vc-data-model]]] states, such extension properties are best
@@ -2112,7 +2558,7 @@ the WebAuthn Level 2 specification, and is currently working to enable the kind
 of <a href="https://github.com/w3c/webauthn/issues/911">cross-origin usage</a>
 that would allow the WebAuthn API to be used for
 <a>verifiable presentations</a>. For example, verifiable credential wallets
-could allow authentication based on verifiable presentations, by using 
+could allow authentication based on verifiable presentations, by using
 WebAuthn authenticators to sign those presentations with challenges from
 verifier websites.
       </section>


### PR DESCRIPTION
This PR migrates the Subject-Holder Relationships Appendix to the Implementation Guide since that section proposes ways to implement various subject-holder relationships (and it was always a bit of a weird fit in the VC Data Model specification).

The corresponding PR in the VC Implementation Guide can be found here: https://github.com/w3c/vc-data-model/pull/897

Merging this PR will resolve this issue: https://github.com/w3c/vc-data-model/issues/879


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/pull/68.html" title="Last updated on Jul 30, 2022, 1:49 PM UTC (9d32258)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-imp-guide/68/801af31...9d32258.html" title="Last updated on Jul 30, 2022, 1:49 PM UTC (9d32258)">Diff</a>